### PR TITLE
Load runtime env and adapt Supabase client

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -18,6 +18,7 @@ This guide provides instructions for building and running TruckTrack in Docker, 
 - **Environment Variables**: Passed at runtime, never stored in image
 - **GitHub Secrets**: Used for CI/CD, never exposed in image
 - **Your Server**: Keeps `.env.local` locally - this file is NEVER committed to git
+- **Browser Runtime Config**: The app now loads Supabase browser config from `/runtime-env.js` at request time, so Portainer or Docker runtime env vars are used without rebuilding the image
 
 ### Recommended Workflow
 
@@ -135,6 +136,8 @@ docker run -p 3000:3000 \
   ghcr.io/your-username/your-repo:latest
 ```
 
+These variables are read by the running container and exposed to the browser through `/runtime-env.js`, so you do not need to rebuild the image after setting them.
+
 **Option B: Docker Compose (Recommended for Production)**
 
 Create a `.env.local` file **only on your docker server** (never in git):
@@ -235,6 +238,9 @@ The multi-stage build:
 - Or use `-e` flag when running: `docker run -e VAR=value ...`
 - Don't forget variables are case-sensitive
 - **Do NOT put env vars in the Dockerfile** - always pass at runtime
+- If you use Portainer, add the env vars to the container or stack service itself and fully recreate or restart the container after changes
+- Verify the running container is serving runtime config by opening `/runtime-env.js` in the browser or curling it from the container host
+- If `/runtime-env.js` shows empty values, the vars are not attached to the running container even if they exist elsewhere in Portainer
 
 ### Secrets exposed in logs
 - Never echo or log environment variables

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import { ThemeSwitcher } from "@/components/theme-switcher";
 import { hasEnvVars } from "@/utils/supabase/check-env-vars";
 import { HeroUIProvider } from "@heroui/react";
 import { Geist } from "next/font/google";
+import Script from "next/script";
 import { ThemeProvider } from "next-themes";
 import Link from "next/link";
 import "./globals.css";
@@ -31,6 +32,7 @@ export default function RootLayout({
   return (
     <html lang="en" className={geistSans.className} suppressHydrationWarning>
       <body className="bg-background text-foreground">
+        <Script src="/runtime-env.js" strategy="beforeInteractive" />
         <ThemeProvider
           attribute="class"
           defaultTheme="system"

--- a/app/runtime-env.js/route.ts
+++ b/app/runtime-env.js/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const payload = {
+    NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL ?? "",
+    NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? "",
+  };
+
+  return new NextResponse(
+    `window.__TRUCKTRACK_ENV = ${JSON.stringify(payload)};`,
+    {
+      headers: {
+        "Content-Type": "application/javascript; charset=utf-8",
+        "Cache-Control": "no-store, must-revalidate",
+      },
+    },
+  );
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,7 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   /* Optimized configuration for latest Next.js */
   reactStrictMode: true,
+  output: "standalone",
   
   // Image optimization
   images: {

--- a/utils/supabase/client.ts
+++ b/utils/supabase/client.ts
@@ -1,7 +1,42 @@
 import { createBrowserClient } from "@supabase/ssr";
 
-export const createClient = () =>
-  createBrowserClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-  );
+declare global {
+  interface Window {
+    __TRUCKTRACK_ENV?: {
+      NEXT_PUBLIC_SUPABASE_URL?: string;
+      NEXT_PUBLIC_SUPABASE_ANON_KEY?: string;
+    };
+  }
+}
+
+let browserClient: ReturnType<typeof createBrowserClient> | null = null;
+
+function getSupabaseBrowserEnv() {
+  if (typeof window !== "undefined") {
+    return {
+      url: window.__TRUCKTRACK_ENV?.NEXT_PUBLIC_SUPABASE_URL ?? "",
+      anonKey: window.__TRUCKTRACK_ENV?.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? "",
+    };
+  }
+
+  return {
+    url: process.env.NEXT_PUBLIC_SUPABASE_URL ?? "",
+    anonKey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? "",
+  };
+}
+
+export const createClient = () => {
+  const { url, anonKey } = getSupabaseBrowserEnv();
+
+  if (!url || !anonKey) {
+    throw new Error(
+      "Supabase environment variables are missing from the running application.",
+    );
+  }
+
+  if (!browserClient) {
+    browserClient = createBrowserClient(url, anonKey);
+  }
+
+  return browserClient;
+};


### PR DESCRIPTION
Add a dynamic /runtime-env.js route that exposes NEXT_PUBLIC_SUPABASE_* vars to the browser at request time (no-store cache). Inject the script in app layout (beforeInteractive) so the client can read runtime config. Update utils/supabase/client to read env from window.__TRUCKTRACK_ENV (with server fallback), cache a single browser Supabase client, and error if required vars are missing. Also enable standalone output in next.config and update DOCKER.md to document the new runtime-env workflow and Portainer/runtime notes.